### PR TITLE
Windows fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,11 @@ const fs = require('fs')
 const portableLock = require('./portable')
 
 let unixLock
-try {
-  unixLock = require('./unix')
-} catch (err) {}
+if (process.platform !== 'win32') {
+  try {
+    unixLock = require('./unix')
+  } catch (err) {}
+}
 
 module.exports = function Lock (isPortable) {
   const locked = {}


### PR DESCRIPTION
After a change in fs-ext, lock-me is trying to use the unix locks even on Windows, failing afterwards on calling fcntl.

This ensures that it will always use the portable version on Windows systems.