### PR TITLE
Fix/windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: node_js
 node_js:
   - 6
   - 8
+  - 10
+
+os:
+  - linux
+  - windows
 
 # Make sure we have new NPM.
 before_install:

--- a/src/portable.js
+++ b/src/portable.js
@@ -20,7 +20,7 @@ module.exports = function lockPortable (name, callback) {
       }
       cb()
     }),
-    (cb) => fs.open(name, 'w+', cb),
+    (cb) => fs.open(name, 'w+', (err, fd) => cb(err, fd)),
     (fd, cb) => {
       fs.write(fd, JSON.stringify({
         ownerPID: process.pid
@@ -54,7 +54,9 @@ function processLockfile (name, callback) {
       case STATUS.LOCKED:
         return callback(new Error(`file ${name} already locked`))
       case STATUS.STALE:
-        return fs.unlink(name, callback)
+        return fs.unlink(name, (err) => {
+          callback(err)
+        })
       case STATUS.INVALID:
         return callback(new Error(`can't lock file ${name}: has invalid content`))
       default:


### PR DESCRIPTION
There is [an issue](https://github.com/nodejs/node/issues/20872) in node 10 where an extra, undefined value is being passed into the fs callbacks. This causes the async methods to fail.

I found the issue on a [jenkins build](https://ci.ipfs.team/blue/organizations/jenkins/IPFS%2Fjs-ipfs/detail/PR-1358/6/pipeline) of windows for js-ipfs. I added windows and node 10 to the travis file for this repo to verify the failure, and then added the fix.

You can see the failure on my fork [here](https://travis-ci.org/jacobheun/lock-me/builds/381863445) with windows node 10 added to travis.
And the fixed build [here](https://travis-ci.org/jacobheun/lock-me/builds/381867661).